### PR TITLE
#1 fix: :wheelchair: Removing all `outline: 0` overrides

### DIFF
--- a/packages/chisel-css/src/chisel.css
+++ b/packages/chisel-css/src/chisel.css
@@ -211,7 +211,6 @@ input[type='submit'] {
         background-color: var(--chisel-neutral-500);
         border-color: var(--chisel-neutral-500);
         color: var(--chisel-neutral-50);
-        outline: 0;
     }
 
     &[disabled] {
@@ -337,7 +336,6 @@ select {
 
     &:focus {
         border-color: var(--chisel-primary);
-        outline: 0;
     }
 }
 


### PR DESCRIPTION
For now, chisel will leave all browser defaults for outlining active or focused elements.